### PR TITLE
feat: allow `tableName ` to contain schema

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -27,6 +27,7 @@ import * as Knex from 'knex';
 export type Config = Knex.Knex.Config & {
   client: keyof Instance;
 };
+
 export type Instance = {
   pg: pg.Client;
   mysql: mysql.Connection;
@@ -284,11 +285,11 @@ export class BasicAdapter<T extends keyof Instance> implements Adapter {
     if (tableExists.length > 0) return;
 
     const createTableSQL = schemaProxy
-      .createTable(table, (table) => {
-        table.increments();
-        table.string('ptype').notNullable();
+      .createTable(table, t => {
+        t.increments();
+        t.string('ptype').notNullable();
         for (const i of ['v0', 'v1', 'v2', 'v3', 'v4', 'v5']) {
-          table.string(i);
+          t.string(i);
         }
       })
       .toQuery();

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -268,14 +268,20 @@ export class BasicAdapter<T extends keyof Instance> implements Adapter {
   }
 
   private async createTable(): Promise<void> {
+    let [schema, table] = this.tableName.split('.');
+    if (!table) {
+        table = schema;
+        schema = void 0;
+    }
+    const $proxy = (schema ? this.knex.schema.withSchema(schema) : this.knex.schema);
     const tableExists = await this.query(
-      this.knex.schema.hasTable(this.tableName).toString(),
+      $proxy.hasTable(table).toString(),
     );
 
     if (tableExists.length > 0) return;
 
-    const createTableSQL = this.knex.schema
-      .createTable(this.tableName, (table) => {
+    const createTableSQL = $proxy
+      .createTable(table, (table) => {
         table.increments();
         table.string('ptype').notNullable();
         for (const i of ['v0', 'v1', 'v2', 'v3', 'v4', 'v5']) {

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -284,8 +284,8 @@ export class BasicAdapter<T extends keyof Instance> implements Adapter {
 
     if (tableExists.length > 0) return;
 
-    const createTableSQL = schemaProxy
-      .createTable(table, t => {
+    const createTableSQL = this.knex.schema
+      .createTable(this.tableName, (t) => {
         t.increments();
         t.string('ptype').notNullable();
         for (const i of ['v0', 'v1', 'v2', 'v3', 'v4', 'v5']) {

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -273,7 +273,9 @@ export class BasicAdapter<T extends keyof Instance> implements Adapter {
     const table = parts.length === 2 ? parts[1] : parts[0];
 
     // use the schema if provided
-    const schemaProxy = schema ? this.knex.schema.withSchema(schema) : this.knex.schema;
+    const schemaProxy = schema
+      ? this.knex.schema.withSchema(schema)
+      : this.knex.schema;
 
     const tableExists = await this.query(
       schemaProxy.hasTable(table).toString(),

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -35,15 +35,18 @@ export type Instance = {
   mssql: mssql.ConnectionPool;
 };
 
-const CasbinRuleTable = 'casbin_rule';
-
 export class BasicAdapter<T extends keyof Instance> implements Adapter {
   private knex: Knex.Knex;
   private config: Config;
   private drive: T;
   private client: Instance[T];
+  private tableName: string;
 
-  private constructor(drive: T, client: Instance[T]) {
+  private constructor(
+    drive: T,
+    client: Instance[T],
+    tableName: string = 'casbin_rule',
+  ) {
     this.config = {
       client: drive,
       useNullAsDefault: drive === 'sqlite3',
@@ -52,13 +55,15 @@ export class BasicAdapter<T extends keyof Instance> implements Adapter {
     this.knex = Knex.knex(this.config);
     this.drive = drive;
     this.client = client;
+    this.tableName = tableName;
   }
 
   static async newAdapter<T extends keyof Instance>(
     drive: T,
     client: Instance[T],
+    tableName: string = 'casbin_rule',
   ): Promise<BasicAdapter<T>> {
-    const a = new BasicAdapter(drive, client);
+    const a = new BasicAdapter(drive, client, tableName);
     await a.connect();
     await a.createTable();
 
@@ -67,7 +72,7 @@ export class BasicAdapter<T extends keyof Instance> implements Adapter {
 
   async loadPolicy(model: Model): Promise<void> {
     const result = await this.query(
-      this.knex.select().from(CasbinRuleTable).toQuery(),
+      this.knex.select().from(this.tableName).toQuery(),
     );
 
     for (const line of result) {
@@ -76,7 +81,7 @@ export class BasicAdapter<T extends keyof Instance> implements Adapter {
   }
 
   async savePolicy(model: Model): Promise<boolean> {
-    await this.query(this.knex.del().from(CasbinRuleTable).toQuery());
+    await this.query(this.knex.del().from(this.tableName).toQuery());
 
     let astMap = model.model.get('p')!;
     const processes: Array<Promise<CasbinRule[]>> = [];
@@ -85,7 +90,7 @@ export class BasicAdapter<T extends keyof Instance> implements Adapter {
       for (const rule of ast.policy) {
         const line = this.savePolicyLine(ptype, rule);
         const p = this.query(
-          this.knex.insert(line).into(CasbinRuleTable).toQuery(),
+          this.knex.insert(line).into(this.tableName).toQuery(),
         );
         processes.push(p);
       }
@@ -96,7 +101,7 @@ export class BasicAdapter<T extends keyof Instance> implements Adapter {
       for (const rule of ast.policy) {
         const line = this.savePolicyLine(ptype, rule);
         const p = this.query(
-          this.knex.insert(line).into(CasbinRuleTable).toQuery(),
+          this.knex.insert(line).into(this.tableName).toQuery(),
         );
         processes.push(p);
       }
@@ -109,7 +114,7 @@ export class BasicAdapter<T extends keyof Instance> implements Adapter {
 
   async addPolicy(sec: string, ptype: string, rule: string[]): Promise<void> {
     const line = this.savePolicyLine(ptype, rule);
-    await this.query(this.knex.insert(line).into(CasbinRuleTable).toQuery());
+    await this.query(this.knex.insert(line).into(this.tableName).toQuery());
   }
 
   async addPolicies(
@@ -121,7 +126,7 @@ export class BasicAdapter<T extends keyof Instance> implements Adapter {
     for (const rule of rules) {
       const line = this.savePolicyLine(ptype, rule);
       const p = this.query(
-        this.knex.insert(line).into(CasbinRuleTable).toQuery(),
+        this.knex.insert(line).into(this.tableName).toQuery(),
       );
       processes.push(p);
     }
@@ -136,7 +141,7 @@ export class BasicAdapter<T extends keyof Instance> implements Adapter {
   ): Promise<void> {
     const line = this.savePolicyLine(ptype, rule);
     await this.query(
-      this.knex.del().where(line).from(CasbinRuleTable).toQuery(),
+      this.knex.del().where(line).from(this.tableName).toQuery(),
     );
   }
 
@@ -149,7 +154,7 @@ export class BasicAdapter<T extends keyof Instance> implements Adapter {
     for (const rule of rules) {
       const line = this.savePolicyLine(ptype, rule);
       const p = this.query(
-        this.knex.del().where(line).from(CasbinRuleTable).toQuery(),
+        this.knex.del().where(line).from(this.tableName).toQuery(),
       );
       processes.push(p);
     }
@@ -186,7 +191,7 @@ export class BasicAdapter<T extends keyof Instance> implements Adapter {
     }
 
     await this.query(
-      this.knex.del().where(line).from(CasbinRuleTable).toQuery(),
+      this.knex.del().where(line).from(this.tableName).toQuery(),
     );
   }
 

--- a/test/mysql-adapter.test.ts
+++ b/test/mysql-adapter.test.ts
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { createConnection } from "mysql";
-import Runner from "./runner";
+import { createConnection } from 'mysql';
+import Runner from './runner';
 
 test(
-  "mysql adapter",
+  'mysql adapter',
   Runner(
-    "mysql",
+    'mysql',
     createConnection({
-      database: "casbin",
-      user: "casbin",
-      password: "password",
+      database: 'casbin',
+      user: 'casbin',
+      password: 'password',
     }),
   ),
   60 * 1000,

--- a/test/mysql-adapter.test.ts
+++ b/test/mysql-adapter.test.ts
@@ -20,9 +20,9 @@ test(
   Runner(
     'mysql',
     createConnection({
+      database: 'casbin',
       user: 'casbin',
       password: 'password',
-      database: 'casbin',
     }),
   ),
   60 * 1000,

--- a/test/mysql-adapter.test.ts
+++ b/test/mysql-adapter.test.ts
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { createConnection } from 'mysql';
-import Runner from './runner';
+import { createConnection } from "mysql";
+import Runner from "./runner";
 
 test(
-  'mysql adapter',
+  "mysql adapter",
   Runner(
-    'mysql',
+    "mysql",
     createConnection({
-      database: 'casbin',
-      user: 'casbin',
-      password: 'password',
+      database: "casbin",
+      user: "casbin",
+      password: "password",
     }),
   ),
   60 * 1000,

--- a/test/mysql2-adapter.test.ts
+++ b/test/mysql2-adapter.test.ts
@@ -20,9 +20,9 @@ test(
   Runner(
     'mysql2',
     createConnection({
+      database: 'casbin',
       user: 'casbin',
       password: 'password',
-      database: 'casbin',
     }),
   ),
   60 * 1000,

--- a/test/mysql2-adapter.test.ts
+++ b/test/mysql2-adapter.test.ts
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { createConnection } from "mysql2/promise";
-import Runner from "./runner";
+import { createConnection } from 'mysql2/promise';
+import Runner from './runner';
 
 test(
-  "mysql2 adapter",
+  'mysql2 adapter',
   Runner(
-    "mysql2",
+    'mysql2',
     createConnection({
-      database: "casbin",
-      user: "casbin",
-      password: "password",
+      database: 'casbin',
+      user: 'casbin',
+      password: 'password',
     }),
   ),
   60 * 1000,

--- a/test/mysql2-adapter.test.ts
+++ b/test/mysql2-adapter.test.ts
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { createConnection } from 'mysql2/promise';
-import Runner from './runner';
+import { createConnection } from "mysql2/promise";
+import Runner from "./runner";
 
 test(
-  'mysql2 adapter',
+  "mysql2 adapter",
   Runner(
-    'mysql2',
+    "mysql2",
     createConnection({
-      database: 'casbin',
-      user: 'casbin',
-      password: 'password',
+      database: "casbin",
+      user: "casbin",
+      password: "password",
     }),
   ),
   60 * 1000,

--- a/test/sqlite3-adapter.test.ts
+++ b/test/sqlite3-adapter.test.ts
@@ -12,14 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Database } from 'sqlite3';
-import Runner from './runner';
+import { Database } from "sqlite3";
+import Runner from "./runner";
 
-test(
-  'sqlite3 adapter',
-  Runner(
-    'sqlite3',
-    new Database(':memory:')
-  ),
-  60 * 1000
-);
+test("sqlite3 adapter", Runner("sqlite3", new Database(":memory:")), 60 * 1000);

--- a/test/sqlite3-adapter.test.ts
+++ b/test/sqlite3-adapter.test.ts
@@ -15,4 +15,11 @@
 import { Database } from 'sqlite3';
 import Runner from './runner';
 
-test('sqlite3 adapter', Runner('sqlite3', new Database(':memory:')), 60 * 1000);
+test(
+  'sqlite3 adapter',
+  Runner(
+    'sqlite3',
+    new Database(':memory:')
+  ),
+  60 * 1000
+);

--- a/test/sqlite3-adapter.test.ts
+++ b/test/sqlite3-adapter.test.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Database } from "sqlite3";
-import Runner from "./runner";
+import { Database } from 'sqlite3';
+import Runner from './runner';
 
-test("sqlite3 adapter", Runner("sqlite3", new Database(":memory:")), 60 * 1000);
+test('sqlite3 adapter', Runner('sqlite3', new Database(':memory:')), 60 * 1000);


### PR DESCRIPTION
Though `createTable` handles tableName with it's schema, `hasTable` does not and requires calling `withSchema` when `tableName` contains the prefixed schema.